### PR TITLE
Cast to int

### DIFF
--- a/main.py
+++ b/main.py
@@ -547,7 +547,7 @@ curdoc().title = "GT7 Dashboard"
 curdoc().add_periodic_callback(update_lap_change, 1000)
 curdoc().add_periodic_callback(update_fuel_map, 5000)
 
-updateFrequency = os.environ.get("GT7_UPDATE_FREQUENCY_MS")
+updateFrequency = int(os.environ.get("GT7_UPDATE_FREQUENCY_MS"))
 if not updateFrequency:
     updateFrequency = 100
 curdoc().add_periodic_callback(update_braking_and_throttle,updateFrequency)


### PR DESCRIPTION
This pull request makes a small change to how the `GT7_UPDATE_FREQUENCY_MS` environment variable is handled in `main.py`. The value is now explicitly converted to an integer before use, ensuring type consistency for the periodic callback.

([main.pyL550-R550](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L550-R550))